### PR TITLE
sub(feat): add meal image storage migration and checklist (#5)

### DIFF
--- a/cascade/initial-image-support.md
+++ b/cascade/initial-image-support.md
@@ -1,0 +1,18 @@
+# Meal Image Upload: Minimal Implementation Plan
+
+1. **Supabase Storage Setup**
+   - [x] Ensure a Supabase storage bucket exists for meal images. *(migration created)*
+
+2. **Database Update**
+   - [x] Add an `image_url` (or similar) column to the `meals` table to store the image path. *(migration created)*
+
+3. **Backend/Types Update**
+   - [ ] Update TypeScript types to include the meal image URL. *(in progress)*
+
+4. **Frontend: Meal Creation**
+   - [ ] Add a file input to the meal creation form for image upload.
+   - [ ] On form submission, upload the image to Supabase Storage and get its URL.
+   - [ ] Save the image URL with the new meal record.
+
+5. **Frontend: Home Page**
+   - [ ] Display the meal image alongside meal details on the home page.

--- a/supabase/migrations/20250530140500_create_meal_images_bucket.sql
+++ b/supabase/migrations/20250530140500_create_meal_images_bucket.sql
@@ -1,0 +1,13 @@
+-- Migration: Create 'meal-images' storage bucket in Supabase
+-- This script uses the storage API to create a bucket for meal images
+
+-- This is a custom SQL migration for Supabase CLI
+-- See: https://supabase.com/docs/guides/storage#managing-storage-buckets-with-sql
+
+-- Create the bucket if it does not exist
+insert into storage.buckets (id, name, public)
+values ('meal-images', 'meal-images', true)
+on conflict (id) do nothing;
+
+-- You may want to set up RLS policies for more fine-grained control.
+-- See Supabase docs for details.

--- a/supabase/migrations/20250530141000_add_image_url_to_meals.sql
+++ b/supabase/migrations/20250530141000_add_image_url_to_meals.sql
@@ -1,0 +1,2 @@
+-- Migration: Add image_url column to meals table
+ALTER TABLE meals ADD COLUMN image_url TEXT;


### PR DESCRIPTION
- Add migration for public meal-images storage bucket (Supabase Storage)
- Add migration for image_url column to meals table
- Create cascade/initial-image-support.md implementation plan checklist

These changes lay the groundwork for minimal meal image upload and display support. Each migration and the plan file are ready for the next steps in the workflow.

First part of the work for #5